### PR TITLE
Make appbar buttons responsive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -250,57 +250,87 @@
           title="Compactar menu"
           class="mr-2"
         />
-        
-        <!-- Left side buttons -->
-        <v-btn
-          color="deep-purple"
-          prepend-icon="mdi-crown"
-          variant="elevated"
-          class="mr-4 funnel-ultimate-btn"
-          @click="openFunnelCenter"
-        >
-          Funnel ULTIMATE
-        </v-btn>
-        
-        <v-btn
-          color="primary"
-          prepend-icon="mdi-chart-timeline-variant"
-          variant="elevated"
-          class="mr-4"
-          @click="openContentCenter"
-        >
-          Content Center
-        </v-btn>
-        
-        <v-btn
-          color="orange"
-          prepend-icon="mdi-factory"
-          variant="elevated"
-          class="mr-4"
-          @click="openCOC"
-        >
-          COC
-        </v-btn>
-        
-        <v-btn
-          color="success"
-          prepend-icon="mdi-flask"
-          variant="elevated"
-          class="hibrit-labs-btn mr-4"
-          @click="() => router.push('/labs')"
-        >
-          HIBRIT LABS
-        </v-btn>
-        
-        <v-btn
-          color="cyan"
-          prepend-icon="mdi-brain"
-          variant="elevated"
-          class="knowledge-nexus-btn"
-          @click="openKnowledgeNexus"
-        >
-          KNOWLEDGE NEXUS
-        </v-btn>
+        <!-- Mobile actions menu -->
+        <v-menu class="d-inline-flex d-md-none">
+          <template #activator="{ props }">
+            <v-btn
+              icon="mdi-dots-vertical"
+              v-bind="props"
+              title="Ações"
+              class="mr-2"
+            />
+          </template>
+          <v-list>
+            <v-list-item prepend-icon="mdi-crown" @click="openFunnelCenter">
+              <v-list-item-title>Funnel ULTIMATE</v-list-item-title>
+            </v-list-item>
+            <v-list-item prepend-icon="mdi-chart-timeline-variant" @click="openContentCenter">
+              <v-list-item-title>Content Center</v-list-item-title>
+            </v-list-item>
+            <v-list-item prepend-icon="mdi-factory" @click="openCOC">
+              <v-list-item-title>COC</v-list-item-title>
+            </v-list-item>
+            <v-list-item prepend-icon="mdi-flask" @click="() => router.push('/labs')">
+              <v-list-item-title>Hibrit Labs</v-list-item-title>
+            </v-list-item>
+            <v-list-item prepend-icon="mdi-brain" @click="openKnowledgeNexus">
+              <v-list-item-title>Knowledge Nexus</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+
+        <!-- Left side buttons (desktop) -->
+        <div class="d-none d-md-flex align-center">
+          <v-btn
+            color="deep-purple"
+            prepend-icon="mdi-crown"
+            variant="elevated"
+            class="mr-4 funnel-ultimate-btn"
+            @click="openFunnelCenter"
+          >
+            Funnel ULTIMATE
+          </v-btn>
+          
+          <v-btn
+            color="primary"
+            prepend-icon="mdi-chart-timeline-variant"
+            variant="elevated"
+            class="mr-4"
+            @click="openContentCenter"
+          >
+            Content Center
+          </v-btn>
+          
+          <v-btn
+            color="orange"
+            prepend-icon="mdi-factory"
+            variant="elevated"
+            class="mr-4"
+            @click="openCOC"
+          >
+            COC
+          </v-btn>
+          
+          <v-btn
+            color="success"
+            prepend-icon="mdi-flask"
+            variant="elevated"
+            class="hibrit-labs-btn mr-4"
+            @click="() => router.push('/labs')"
+          >
+            HIBRIT LABS
+          </v-btn>
+          
+          <v-btn
+            color="cyan"
+            prepend-icon="mdi-brain"
+            variant="elevated"
+            class="knowledge-nexus-btn"
+            @click="openKnowledgeNexus"
+          >
+            KNOWLEDGE NEXUS
+          </v-btn>
+        </div>
         
         <v-spacer />
         
@@ -340,10 +370,18 @@
           color="error"
           prepend-icon="mdi-close"
           @click="stopSimulation"
-          class="ml-2"
+          class="ml-2 d-none d-sm-inline-flex"
         >
           Sair da Simulação
         </v-btn>
+        <v-btn
+          v-if="simulationStore.isSimulating"
+          icon="mdi-close"
+          color="error"
+          class="ml-2 d-inline-flex d-sm-none"
+          @click="stopSimulation"
+          title="Sair da Simulação"
+        />
         
         <v-menu>
           <template #activator="{ props }">

--- a/src/views/Flow.vue
+++ b/src/views/Flow.vue
@@ -10,27 +10,63 @@
       
       <v-spacer />
       
-      <v-btn-group density="compact">
-        <v-btn
-          :color="focusMode ? 'primary' : 'default'"
-          @click="toggleFocusMode"
-        >
-          <v-icon>mdi-focus-field</v-icon>
-          Focus
-        </v-btn>
-        <v-btn @click="fitView">
-          <v-icon>mdi-fit-to-screen</v-icon>
-          Fit
-        </v-btn>
-        <v-btn @click="exportCanvas">
-          <v-icon>mdi-download</v-icon>
-          Export
-        </v-btn>
-        <v-btn @click="startStoryMode" color="success">
-          <v-icon>mdi-play</v-icon>
-          Tour 30s
-        </v-btn>
-      </v-btn-group>
+      <!-- Mobile overflow menu -->
+      <v-menu class="d-inline-flex d-md-none">
+        <template #activator="{ props }">
+          <v-btn icon="mdi-dots-vertical" v-bind="props" title="Ações" />
+        </template>
+        <v-list>
+          <v-list-item @click="toggleFocusMode">
+            <template #prepend>
+              <v-icon>mdi-focus-field</v-icon>
+            </template>
+            <v-list-item-title>{{ focusMode ? 'Focus: On' : 'Focus: Off' }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="fitView">
+            <template #prepend>
+              <v-icon>mdi-fit-to-screen</v-icon>
+            </template>
+            <v-list-item-title>Fit</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="exportCanvas">
+            <template #prepend>
+              <v-icon>mdi-download</v-icon>
+            </template>
+            <v-list-item-title>Export</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="startStoryMode">
+            <template #prepend>
+              <v-icon>mdi-play</v-icon>
+            </template>
+            <v-list-item-title>Tour 30s</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <!-- Desktop button group -->
+      <div class="d-none d-md-inline-flex">
+        <v-btn-group density="compact">
+          <v-btn
+            :color="focusMode ? 'primary' : 'default'"
+            @click="toggleFocusMode"
+          >
+            <v-icon>mdi-focus-field</v-icon>
+            Focus
+          </v-btn>
+          <v-btn @click="fitView">
+            <v-icon>mdi-fit-to-screen</v-icon>
+            Fit
+          </v-btn>
+          <v-btn @click="exportCanvas">
+            <v-icon>mdi-download</v-icon>
+            Export
+          </v-btn>
+          <v-btn @click="startStoryMode" color="success">
+            <v-icon>mdi-play</v-icon>
+            Tour 30s
+          </v-btn>
+        </v-btn-group>
+      </div>
     </v-app-bar>
 
     <!-- Breadcrumb -->

--- a/src/views/FunnelBuilder.vue
+++ b/src/views/FunnelBuilder.vue
@@ -10,65 +10,127 @@
       </v-toolbar-title>
       
       <v-spacer />
-      
-      <!-- Janela de tempo -->
-      <v-btn-group density="compact" class="mr-4">
-        <v-btn
-          v-for="window in [5, 30, 120]"
-          :key="window"
-          :color="timeWindow === window ? 'primary' : 'default'"
-          size="small"
-          @click="timeWindow = window"
-        >
-          {{ window }}min
-        </v-btn>
-      </v-btn-group>
-      
-      <!-- Modo de visualização -->
-      <v-btn-group density="compact" class="mr-4">
-        <v-btn
-          :color="viewMode === 'design' ? 'primary' : 'default'"
-          @click="viewMode = 'design'"
-        >
-          <v-icon>mdi-pencil</v-icon>
-          Design
-        </v-btn>
-        <v-btn
-          :color="viewMode === 'live' ? 'success' : 'default'"
-          @click="toggleLiveMode"
-        >
-          <v-icon>mdi-pulse</v-icon>
-          Live
-        </v-btn>
-      </v-btn-group>
-      
-      <v-btn-group density="compact">
-        <v-btn @click="autoLayout">
-          <v-icon>mdi-auto-fix</v-icon>
-          Auto
-        </v-btn>
-        <v-btn @click="fitView">
-          <v-icon>mdi-fit-to-screen</v-icon>
-          Fit
-        </v-btn>
-        <v-btn @click="downloadFunnel">
-          <v-icon>mdi-download</v-icon>
-          Download
-        </v-btn>
-        <v-btn @click="toggleCompactMode">
-          <v-icon>{{ compactMode ? 'mdi-view-list' : 'mdi-view-comfy' }}</v-icon>
-          {{ compactMode ? 'Detalhado' : 'Compacto' }}
-        </v-btn>
+
+      <!-- Mobile overflow menu -->
+      <v-menu class="d-inline-flex d-md-none">
+        <template #activator="{ props }">
+          <v-btn icon="mdi-dots-vertical" v-bind="props" title="Ações" />
+        </template>
+        <v-list>
+          <v-list-subheader>Janela</v-list-subheader>
+          <v-list-item
+            v-for="window in [5, 30, 120]"
+            :key="`mob-${window}`"
+            @click="timeWindow = window"
+          >
+            <v-list-item-title>{{ window }}min</v-list-item-title>
+            <template #append>
+              <v-icon v-if="timeWindow === window" color="primary">mdi-check</v-icon>
+            </template>
+          </v-list-item>
+
+          <v-divider class="my-1" />
+          <v-list-subheader>Modo</v-list-subheader>
+          <v-list-item @click="viewMode = 'design'">
+            <template #prepend><v-icon>mdi-pencil</v-icon></template>
+            <v-list-item-title>Design</v-list-item-title>
+            <template #append>
+              <v-icon v-if="viewMode === 'design'" color="primary">mdi-check</v-icon>
+            </template>
+          </v-list-item>
+          <v-list-item @click="toggleLiveMode">
+            <template #prepend><v-icon>mdi-pulse</v-icon></template>
+            <v-list-item-title>Live</v-list-item-title>
+            <template #append>
+              <v-icon v-if="viewMode === 'live'" color="success">mdi-check</v-icon>
+            </template>
+          </v-list-item>
+
+          <v-divider class="my-1" />
+          <v-list-item @click="autoLayout">
+            <template #prepend><v-icon>mdi-auto-fix</v-icon></template>
+            <v-list-item-title>Auto</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="fitView">
+            <template #prepend><v-icon>mdi-fit-to-screen</v-icon></template>
+            <v-list-item-title>Fit</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="downloadFunnel">
+            <template #prepend><v-icon>mdi-download</v-icon></template>
+            <v-list-item-title>Download</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="toggleCompactMode">
+            <template #prepend><v-icon>{{ compactMode ? 'mdi-view-list' : 'mdi-view-comfy' }}</v-icon></template>
+            <v-list-item-title>{{ compactMode ? 'Detalhado' : 'Compacto' }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="startQuickTour">
+            <template #prepend><v-icon>mdi-help-circle</v-icon></template>
+            <v-list-item-title>Ajuda</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+
+      <!-- Desktop groups -->
+      <div class="d-none d-md-inline-flex align-center">
+        <!-- Janela de tempo -->
+        <v-btn-group density="compact" class="mr-4">
+          <v-btn
+            v-for="window in [5, 30, 120]"
+            :key="window"
+            :color="timeWindow === window ? 'primary' : 'default'"
+            size="small"
+            @click="timeWindow = window"
+          >
+            {{ window }}min
+          </v-btn>
+        </v-btn-group>
         
-        <!-- Botão de ajuda -->
-        <v-btn 
-          icon="mdi-help-circle"
-          variant="text"
-          color="white"
-          @click="startQuickTour"
-          class="ml-2"
-        />
-      </v-btn-group>
+        <!-- Modo de visualização -->
+        <v-btn-group density="compact" class="mr-4">
+          <v-btn
+            :color="viewMode === 'design' ? 'primary' : 'default'"
+            @click="viewMode = 'design'"
+          >
+            <v-icon>mdi-pencil</v-icon>
+            Design
+          </v-btn>
+          <v-btn
+            :color="viewMode === 'live' ? 'success' : 'default'"
+            @click="toggleLiveMode"
+          >
+            <v-icon>mdi-pulse</v-icon>
+            Live
+          </v-btn>
+        </v-btn-group>
+        
+        <v-btn-group density="compact">
+          <v-btn @click="autoLayout">
+            <v-icon>mdi-auto-fix</v-icon>
+            Auto
+          </v-btn>
+          <v-btn @click="fitView">
+            <v-icon>mdi-fit-to-screen</v-icon>
+            Fit
+          </v-btn>
+          <v-btn @click="downloadFunnel">
+            <v-icon>mdi-download</v-icon>
+            Download
+          </v-btn>
+          <v-btn @click="toggleCompactMode">
+            <v-icon>{{ compactMode ? 'mdi-view-list' : 'mdi-view-comfy' }}</v-icon>
+            {{ compactMode ? 'Detalhado' : 'Compacto' }}
+          </v-btn>
+          
+          <!-- Botão de ajuda -->
+          <v-btn 
+            icon="mdi-help-circle"
+            variant="text"
+            color="white"
+            @click="startQuickTour"
+            class="ml-2"
+          />
+        </v-btn-group>
+      </div>
     </v-app-bar>
 
     <div class="funnel-builder">


### PR DESCRIPTION
Make app bar buttons and items responsive across `App.vue`, `Flow.vue`, and `FunnelBuilder.vue` to improve mobile usability.

This PR hides full button groups on small screens, replacing them with mobile-friendly `v-menu` overflow actions. The 'Sair da Simulação' button in `App.vue` now displays as an icon on mobile, and `FunnelBuilder.vue`'s multiple button groups are consolidated into a single mobile menu with subheaders for better organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-37261571-bdaa-4713-a4d0-2ba2ba4bf381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37261571-bdaa-4713-a4d0-2ba2ba4bf381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

